### PR TITLE
Dockerfile: use https to download deb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Ryan Flagler
 # global environment settings
 ENV DEBIAN_FRONTEND="noninteractive" \
 COMPANY_NAME="networkoptix" \
-SOFTWARE_URL="http://updates.networkoptix.com/default/29287/linux/nxwitness-server-3.2.0.29287-linux64.deb"
+SOFTWARE_URL="https://updates.networkoptix.com/default/29287/linux/nxwitness-server-3.2.0.29287-linux64.deb"
 
 # install packages
 RUN \


### PR DESCRIPTION
Even though the link on their site uses HTTP, it works with HTTPS.
As I don't think dpkg-deb -R verifies the signatures on the downloaded file, this is more important than usual.